### PR TITLE
End-to-end multihash digest generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 
 language: python
 python:
+  - 3.9
   - 3.8
   - 3.7
   - 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
   - 3.8
   - 3.7
   - 3.6
-  - 3.5
 
 cache: pip
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors

--- a/README.rst
+++ b/README.rst
@@ -23,18 +23,47 @@ Multihash implementation in Python
 
 * Free software: MIT license
 * Documentation: https://multihash.readthedocs.io.
-* Python versions: Python 3.4, 3.5, 3.6
+* Python versions: Python 3.6, 3.8, 3.8, 3.9
 
-Example usage::
+
+Example usage for end-to-end hashing::
     
     import multihash
 
-    # compute multihash digest as bytes
-    multihash_bytes = multihash.digest(b'hello world', 'sha2-256')
-    print(multihash.to_b58_string(multihash_bytes))
+    # 1. compute multihash digest as bytes
+    multihash_digest = multihash.digest(b'hello world', 'sha2-256')
+    print(multihash_digest.hex())
+    # 1220b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+
+    # 2. encode multihash bytes to base58 string
+    print(multihash.to_b58_string(multihash_digest))
     # QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4
 
-    # compute multihash digest as base58 string
-    multihash_str = multihash.b58digest(b'hello world', 'sha2-256')
-    print(multihash_str)
+    # 1. compute multihash digest directly as base58 string
+    multihash_digest_str = multihash.b58digest(b'hello world', 'sha2-256')
+    print(multihash_digest_str)
+    # QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4
+
+
+Example usage with pre-computed hash (e.g. using `hashlib`)::
+
+    import hashlib
+    import multihash
+
+    # 1. hash your data
+    m = hashlib.sha256()
+    m.update(b'hello world')
+    raw_digest = m.digest()
+
+    # 2. add multihash header to raw digest bytes, see that your data follows the header:
+    multihash_digest = multihash.encode(raw_digest, 'sha2-256')
+    print('    '+raw_digest.hex())
+    print(multihash_digest.hex())
+    #     b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+    # 1220b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+    # ^^^^ header 0x1220: 0x12 is the 'sha2-256' code, 0x20 is the hash length
+
+    # 4. encode multihash bytes to base58 string
+    multihash_digest_str = multihash.to_b58_string(multihash_digest)
+    print(multihash_digest_str)
     # QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4

--- a/README.rst
+++ b/README.rst
@@ -25,3 +25,16 @@ Multihash implementation in Python
 * Documentation: https://multihash.readthedocs.io.
 * Python versions: Python 3.4, 3.5, 3.6
 
+Example usage::
+    
+    import multihash
+
+    # compute multihash digest as bytes
+    multihash_bytes = multihash.digest(b'hello world', 'sha2-256')
+    print(multihash.to_b58_string(multihash_bytes))
+    # QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4
+
+    # compute multihash digest as base58 string
+    multihash_str = multihash.b58digest(b'hello world', 'sha2-256')
+    print(multihash_str)
+    # QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -2,43 +2,44 @@
 Usage
 =====
 
-To use `py-multihash` in a project::
+Example usage for end-to-end hashing::
+    
+    import multihash
+
+    # 1. compute multihash digest as bytes
+    multihash_digest = multihash.digest(b'hello world', 'sha2-256')
+    print(multihash_digest.hex())
+    # 1220b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+
+    # 2. encode multihash bytes to base58 string
+    print(multihash.to_b58_string(multihash_digest))
+    # QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4
+
+    # 1. compute multihash digest directly as base58 string
+    multihash_digest_str = multihash.b58digest(b'hello world', 'sha2-256')
+    print(multihash_digest_str)
+    # QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4
+
+
+Example usage with pre-computed hash (e.g. using `hashlib`)::
 
     import hashlib
     import multihash
 
-    # hash your data
+    # 1. hash your data
     m = hashlib.sha256()
     m.update(b'hello world')
     raw_digest = m.digest()
 
-    # add multihash header
-    multihash_bytes = multihash.encode(raw_digest, 'sha2-256')
-
-    # encode it to a string
-    multihash_str = multihash.to_b58_string(multihash_digest)
-
-    print(multihash_str)
-    # QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4
-
-To see that your data follows the header::
-
-    print('  ', m.hexdigest())
-    print(multihash.to_hex_string(multihash_digest))
-
+    # 2. add multihash header to raw digest bytes, see that your data follows the header:
+    multihash_digest = multihash.encode(raw_digest, 'sha2-256')
+    print('    '+raw_digest.hex())
+    print(multihash_digest.hex())
     #     b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
     # 1220b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+    # ^^^^ header 0x1220: 0x12 is the 'sha2-256' code, 0x20 is the hash length
 
-The multihash digest can also be computed directly::
-    
-    import multihash
-
-    # compute multihash digest as bytes
-    multihash_bytes = multihash.digest(b'hello world', 'sha2-256')
-    print(multihash.to_b58_string(multihash_bytes))
-    # QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4
-
-    # compute multihash digest as base58 string
-    multihash_str = multihash.b58digest(b'hello world', 'sha2-256')
-    print(multihash_str)
+    # 4. encode multihash bytes to base58 string
+    multihash_digest_str = multihash.to_b58_string(multihash_digest)
+    print(multihash_digest_str)
     # QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -2,7 +2,7 @@
 Usage
 =====
 
-To use py-multihash in a project::
+To use `py-multihash` in a project::
 
     import hashlib
     import multihash
@@ -13,12 +13,12 @@ To use py-multihash in a project::
     raw_digest = m.digest()
 
     # add multihash header
-    multihash_digest = multihash.encode(raw_digest, "sha2-256")
+    multihash_bytes = multihash.encode(raw_digest, 'sha2-256')
 
     # encode it to a string
-    multihashed_str = multihash.to_b58_string(multihash_digest)
+    multihash_str = multihash.to_b58_string(multihash_digest)
 
-    print(multihashed_str)
+    print(multihash_str)
     # QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4
 
 To see that your data follows the header::
@@ -28,3 +28,17 @@ To see that your data follows the header::
 
     #     b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
     # 1220b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+
+The multihash digest can also be computed directly::
+    
+    import multihash
+
+    # compute multihash digest as bytes
+    multihash_bytes = multihash.digest(b'hello world', 'sha2-256')
+    print(multihash.to_b58_string(multihash_bytes))
+    # QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4
+
+    # compute multihash digest as base58 string
+    multihash_str = multihash.b58digest(b'hello world', 'sha2-256')
+    print(multihash_str)
+    # QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4

--- a/multihash/__init__.py
+++ b/multihash/__init__.py
@@ -6,7 +6,8 @@ __author__ = """Dhruv Baldawa"""
 __email__ = 'dhruv@dhruvb.com'
 __version__ = '2.0.0'
 
-from .multihash import (
-    Multihash, to_hex_string, from_hex_string, to_b58_string, from_b58_string, is_app_code,
-    coerce_code, is_valid_code, decode, encode, is_valid, get_prefix, digest
+from .multihash import (  # noqa: F401
+    Multihash, decode, encode, digest, b58digest,
+    to_hex_string, from_hex_string, to_b58_string, from_b58_string,
+    is_app_code, coerce_code, is_valid_code, is_valid, get_prefix
 )

--- a/multihash/__init__.py
+++ b/multihash/__init__.py
@@ -8,5 +8,5 @@ __version__ = '2.0.0'
 
 from .multihash import (
     Multihash, to_hex_string, from_hex_string, to_b58_string, from_b58_string, is_app_code,
-    coerce_code, is_valid_code, decode, encode, is_valid, get_prefix,
+    coerce_code, is_valid_code, decode, encode, is_valid, get_prefix, digest
 )

--- a/multihash/constants.py
+++ b/multihash/constants.py
@@ -350,16 +350,16 @@ HASH_TABLE = (
 )
 
 HASH_CODES: Mapping[str, int] = {
-    x['hash']: x['code'] # type: ignore
+    x['hash']: x['code']  # type: ignore
     for x in HASH_TABLE
 }
 
 CODE_HASHES: Mapping[int, str] = {
-    x['code']: x['hash'] # type: ignore
+    x['code']: x['hash']  # type: ignore
     for x in HASH_TABLE
 }
 
 HASH_LENGTHS: Mapping[int, Optional[int]] = {
-    x['code']: x.get('length') # type: ignore
+    x['code']: x.get('length')  # type: ignore
     for x in HASH_TABLE
 }

--- a/multihash/constants.py
+++ b/multihash/constants.py
@@ -1,3 +1,11 @@
+"""
+    This module exposes the following tables:
+
+    - `HASH_CODES` maps hash function names to the corresponding numerical codes
+    - `CODE_HASHES` maps hash function codes to the corresponding human-readable names
+    - `HASH_LENGTHS` maps hash function codes to the length of the hashes
+"""
+
 HASH_TABLE = (
     {'code': 0x0, 'hash': 'id'},
     {'code': 0x11, 'length': 0x14, 'hash': 'sha1'},

--- a/multihash/constants.py
+++ b/multihash/constants.py
@@ -6,6 +6,9 @@
     - `HASH_LENGTHS` maps hash function codes to the length of the hashes
 """
 
+from typing import Mapping, Optional
+
+# in 3.8+, this can be statically typed with a TypedDict.
 HASH_TABLE = (
     {'code': 0x0, 'hash': 'id'},
     {'code': 0x11, 'length': 0x14, 'hash': 'sha1'},
@@ -346,6 +349,17 @@ HASH_TABLE = (
     {'code': 0xb3e0, 'length': 0x80, 'hash': 'Skein1024-1024'},
 )
 
-HASH_CODES = {x['hash']: x['code'] for x in HASH_TABLE}
-CODE_HASHES = {x['code']: x['hash'] for x in HASH_TABLE}
-HASH_LENGTHS = {x['code']: x.get('length') for x in HASH_TABLE}
+HASH_CODES: Mapping[str, int] = {
+    x['hash']: x['code'] # type: ignore
+    for x in HASH_TABLE
+}
+
+CODE_HASHES: Mapping[int, str] = {
+    x['code']: x['hash'] # type: ignore
+    for x in HASH_TABLE
+}
+
+HASH_LENGTHS: Mapping[int, Optional[int]] = {
+    x['code']: x.get('length') # type: ignore
+    for x in HASH_TABLE
+}

--- a/multihash/multihash.py
+++ b/multihash/multihash.py
@@ -9,9 +9,9 @@ import hashlib
 from io import BytesIO
 from typing import NamedTuple, Optional, Union
 
-import base58 # type: ignore
-import skein # type: ignore
-import varint # type: ignore
+import base58  # type: ignore
+import skein  # type: ignore
+import varint  # type: ignore
 
 from multihash import constants
 
@@ -45,6 +45,7 @@ def to_hex_string(multihash: bytes) -> str:
     :rtype: str
     :raises: `TypeError`, if the `multihash` has incorrect type
     """
+    # TODO: consider deprecating this, since `bytes.hex()` is a built-in instance method.
     if not isinstance(multihash, bytes):
         raise TypeError('multihash should be bytes, not {}'.format(type(multihash)))
 
@@ -60,6 +61,7 @@ def from_hex_string(multihash: str) -> bytes:
     :rtype: bytes
     :raises: `TypeError`, if the `multihash` has incorrect type
     """
+    # TODO: consider deprecating this, since `bytes.fromhex(string)` is a built-in class method.
     if not isinstance(multihash, str):
         raise TypeError('multihash should be str, not {}'.format(type(multihash)))
 
@@ -282,6 +284,7 @@ def digest(data: bytes, hash_fn: Union[int, str]) -> bytes:
         raise ValueError('Unsupported end-to-end hashing for hash function {}'.format(hash_label))
     return encode(digest, hash_fn, length=length)
 
+
 def b58digest(data: bytes, hash_fn: Union[int, str]) -> str:
     """
     End-to-end multi-hashing of given `data`, using given hash function (by name or code).
@@ -334,7 +337,7 @@ def _digest_hashlib(hash_fn: str, data: bytes, length: Optional[int]) -> Optiona
             return None
     m.update(data)
     if family == 'shake':
-        digest = m.digest(length)
+        digest = m.digest(length)  # type: ignore
     else:
         digest = m.digest()
     assert len(digest) == length

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,4 +11,4 @@ twine==1.14.0
 watchdog[watchmedo]==0.10.3
 wheel
 codecov
-skein=1.0
+pyskein==1.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,3 +11,4 @@ twine==1.14.0
 watchdog[watchmedo]==0.10.3
 wheel
 codecov
+skein=1.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,4 +11,3 @@ twine==1.14.0
 watchdog[watchmedo]==0.10.3
 wheel
 codecov
-pyskein==1.0

--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,10 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = [
-    'varint>=1.0.2,<2.0',
-    'six>=1.10.0,<2.0',
-    'morphys>=1.0,<2.0',
-    'base58>=1.0.2,<3.0',
-    'pyskein>=1.0,<2.0'
+    'varint>=1.0.2',  # tested with 1.0.2
+    'six>=1.10.0',    # tested with 1.16.0
+    'base58>=1.0.2',  # tested with 2.1.0
+    'pyskein>=1.0'    # tested with 1.0
 ]
 
 setup_requirements = ['pytest-runner', ]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 """The setup script."""
 
-from setuptools import setup, find_packages
+from setuptools import setup, find_packages #type: ignore
 
 with open('README.rst') as readme_file:
     readme = readme_file.read()
@@ -16,6 +16,7 @@ requirements = [
     'six>=1.10.0,<2.0',
     'morphys>=1.0,<2.0',
     'base58>=1.0.2,<3.0',
+    'pyskein>=1.0,<2.0'
 ]
 
 setup_requirements = ['pytest-runner', ]
@@ -38,12 +39,13 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
+        "Typing :: Typed",
 
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     install_requires=requirements,
     license="MIT license",
@@ -55,4 +57,7 @@ setup(
     tests_require=test_requirements,
     url='https://github.com/multiformats/multihash',
     zip_safe=False,
+    package_data={"": [],
+                  "multihash": ["multihash/py.typed"],
+                 },
 )

--- a/tests/test_multihash.py
+++ b/tests/test_multihash.py
@@ -2,17 +2,18 @@
 # -*- coding: utf-8 -*-
 
 """Tests for `multihash` package."""
+# pylint: disable = missing-function-docstring, missing-class-docstring, no-self-use
+
 from binascii import hexlify
 import hashlib
 
 import base58
 import pytest
-import varint
-import skein
+import skein  # type: ignore
 
 from multihash import (
-    encode, decode, from_hex_string, to_hex_string, to_b58_string, from_b58_string, is_app_code, is_valid,
-    is_valid_code, get_prefix, coerce_code, digest
+    encode, decode, from_hex_string, to_hex_string, to_b58_string, from_b58_string, is_app_code,
+    is_valid, is_valid_code, get_prefix, coerce_code, digest
 )
 from multihash.constants import HASH_TABLE
 
@@ -90,12 +91,13 @@ INVALID_TABLE = (
     {
         'code': 0xb23f,
         'length': 0x3f,
-        'hex': '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e72c26b46b6f8ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e'
+        'hex': ('2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7'
+                '2c26b46b6f8ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e')
     },
 )
 
-INVALID_BYTE_TYPES = ('a', 1, 1.0, [], {})
-INVALID_STRING_TYPES = (b'a', 1, 1.0, [], {})
+INVALID_BYTE_TYPES: tuple = ('a', 1, 1.0, [], {})
+INVALID_STRING_TYPES: tuple = (b'a', 1, 1.0, [], {})
 
 
 def make_hash(code, size, hex_):
@@ -104,7 +106,7 @@ def make_hash(code, size, hex_):
         bytes.fromhex(hex_)
 
 
-class ToHexStringTestCase(object):
+class ToHexStringTestCase:
     @pytest.mark.parametrize('value', VALID_TABLE)
     def test_to_hex_string_valid(self, value):
         """ to_hex_string: test if it passes for all valid cases """
@@ -120,7 +122,7 @@ class ToHexStringTestCase(object):
         assert 'multihash should be bytes' in str(excinfo.value)
 
 
-class FromHexStringTestCase(object):
+class FromHexStringTestCase:
     @pytest.mark.parametrize('value', VALID_TABLE)
     def test_from_digest_string_valid(self, value):
         """ from_hex_string: decodes the correct values """
@@ -136,7 +138,7 @@ class FromHexStringTestCase(object):
         assert 'multihash should be str' in str(excinfo.value)
 
 
-class To58StringTestCase(object):
+class To58StringTestCase:
     @pytest.mark.parametrize('value', VALID_TABLE)
     def test_to_b58_string_valid(self, value):
         """ to_b58_string: test if it passes for all valid cases """
@@ -152,7 +154,7 @@ class To58StringTestCase(object):
         assert 'multihash should be bytes' in str(excinfo.value)
 
 
-class FromB58StringTestCase(object):
+class FromB58StringTestCase:
     def test_from_b58_string_valid(self):
         """ from_b58_string: test if it passes for all valid cases """
         expected = 'QmPfjpVaf593UQJ9a5ECvdh2x17XuJYG5Yanv5UFnH3jPE'
@@ -167,7 +169,7 @@ class FromB58StringTestCase(object):
         assert 'multihash should be str' in str(excinfo.value)
 
 
-class IsAppCodeTestCase(object):
+class IsAppCodeTestCase:
     @pytest.mark.parametrize('value', (0x01, 0x0f, 0x04))
     def test_is_app_code_valid(self, value):
         """ is_app_code: returns True for all valid cases """
@@ -179,7 +181,7 @@ class IsAppCodeTestCase(object):
         assert not is_app_code(value)
 
 
-class CoerceCodeTestCase(object):
+class CoerceCodeTestCase:
     @pytest.mark.parametrize('value', HASH_TABLE[:15] + HASH_TABLE[:15])
     def test_coerce_code_valid(self, value):
         """ coerce_code: returns code for all valid cases """
@@ -201,7 +203,7 @@ class CoerceCodeTestCase(object):
         assert 'should be either an integer or a string' in str(excinfo.value)
 
 
-class IsValidCodeTestCase(object):
+class IsValidCodeTestCase:
     @pytest.mark.parametrize('value', (0x02, 0x0f, 0x13))
     def test_is_valid_code_valid(self, value):
         """ is_valid_code: returns True for all valid cases """
@@ -213,7 +215,7 @@ class IsValidCodeTestCase(object):
         assert not is_valid_code(value)
 
 
-class DecodeTestCase(object):
+class DecodeTestCase:
     @pytest.mark.parametrize('value', VALID_TABLE)
     def test_decode_valid(self, value):
         """ decode: works for all valid cases """
@@ -286,15 +288,19 @@ class DecodeTestCase(object):
             decode(value)
         assert 'Invalid varint provided' in str(excinfo.value)
 
-class EncodeTestCase(object):
+
+class EncodeTestCase:
+
     @pytest.mark.parametrize('value', VALID_TABLE)
     def test_encode_valid(self, value):
         """ encode: encodes stuff for all valid cases """
         code = value['encoding']['code']
         actual = make_hash(code, value['length'], value['hex'])
         name = value['encoding']['name']
-        assert hexlify(encode(bytes.fromhex(value['hex']), code, value['length'])) == hexlify(actual)
-        assert hexlify(encode(bytes.fromhex(value['hex']), name, value['length'])) == hexlify(actual)
+        assert (hexlify(encode(bytes.fromhex(value['hex']), code, value['length']))
+                == hexlify(actual))  # note: round brackets only for line continuation
+        assert (hexlify(encode(bytes.fromhex(value['hex']), name, value['length']))
+                == hexlify(actual))  # note: round brackets only for line continuation
 
     @pytest.mark.parametrize('value', VALID_TABLE)
     def test_encode_no_length(self, value):
@@ -321,7 +327,9 @@ class EncodeTestCase(object):
             encode(value, 0x11)
         assert 'must be a bytes object' in str(excinfo.value)
 
-class IsValidTestCase(object):
+
+class IsValidTestCase:
+
     @pytest.mark.parametrize('value', VALID_TABLE)
     def test_is_valid_valid(self, value):
         """ is_valid: returns True for all valid cases """
@@ -333,7 +341,7 @@ class IsValidTestCase(object):
         assert not is_valid(make_hash(value['code'], value['length'], value['hex']))
 
 
-class GetPrefixTestCase(object):
+class GetPrefixTestCase:
     def test_get_prefix_valid(self):
         """ get_prefix: returns valid prefix """
         multihash = encode(b'foo', 0x11, 3)
@@ -349,31 +357,37 @@ class GetPrefixTestCase(object):
 def id_digest(data):
     return data
 
+
 def sha1_digest(data):
     m = hashlib.sha1()
     m.update(data)
     return m.digest()
+
 
 def sha2_digest(data, length):
     m = getattr(hashlib, 'sha{}'.format(length*8))()
     m.update(data)
     return m.digest()
 
+
 def sha3_digest(data, length):
     m = getattr(hashlib, 'sha3_{}'.format(length*8))()
     m.update(data)
     return m.digest()
+
 
 def shake_digest(data, length):
     m = getattr(hashlib, 'shake_{}'.format(length*4))()
     m.update(data)
     return m.digest(length)
 
+
 def blake2_digest(data, variant, length):
     assert variant in ('b', 's')
     m = getattr(hashlib, 'blake2{}'.format(variant))(digest_size=length)
     m.update(data)
     return m.digest()
+
 
 def skein_digest(data, variant, length):
     assert variant in (256, 512, 1024)
@@ -384,7 +398,7 @@ def skein_digest(data, variant, length):
 
 DIGEST_DATA = {
     prefix: tuple(
-        { 'data': b"Bytes to be hashed.", 'length': length }
+        {'data': b"Bytes to be hashed.", 'length': length}
         for length in (entry.get('length') for entry in HASH_TABLE
                        if str(entry['hash']).startswith(prefix))
     )
@@ -393,20 +407,20 @@ DIGEST_DATA = {
 }
 
 
-class DigestTestCase(object):
+class DigestTestCase:
 
     @pytest.mark.parametrize('value', DIGEST_DATA['id'])
     def test_id(self, value):
         """ test_id: id hash works """
         hash_fn = 'id'
-        data, length = (value['data'], value['length'])
+        data, _ = (value['data'], value['length'])
         assert encode(id_digest(data), hash_fn) == digest(data, hash_fn)
 
     @pytest.mark.parametrize('value', DIGEST_DATA['sha1'])
     def test_sha1(self, value):
         """ test_sha1: sha1 hash works """
         hash_fn = 'sha1'
-        data, length = (value['data'], value['length'])
+        data, _ = (value['data'], value['length'])
         assert encode(sha1_digest(data), hash_fn) == digest(data, hash_fn)
 
     @pytest.mark.parametrize('value', DIGEST_DATA['sha2'])

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py35, py36, py37, py38, flake8
+envlist = py36, py37, py38, py39, flake8
 
 [travis]
 python =
+    3.9: py39
     3.8: py38
     3.7: py37
     3.6: py36
-    3.5: py35
 
 [testenv:flake8]
 basepython = python


### PR DESCRIPTION
Introduces `digest` and `b58digest` functions that compute multihash digests directly from data and a choice of hash function. Includes a number of minor cosmetic changes, as well as static types.