### PR TITLE
Implement Multihash stream read/write method

### DIFF
--- a/multihash/multihash.py
+++ b/multihash/multihash.py
@@ -245,9 +245,6 @@ class Multihash(namedtuple("Multihash", "code,name,length,digest")):
         except (TypeError, ValueError) as e:
             raise ValueError(f"Failed to read multihash length from stream: {e}") from e
 
-        if length < 0:
-            raise ValueError(f"Invalid multihash length: {length}")
-
         digest = stream.read(length)
         if len(digest) != length:
             raise ValueError(f"Insufficient data in stream: expected {length} bytes, got {len(digest)}")
@@ -269,7 +266,7 @@ class Multihash(namedtuple("Multihash", "code,name,length,digest")):
 
         Raises:
             TypeError: If stream is not a valid binary stream
-            IOError: If writing to the stream fails
+            OSError: If writing to the stream fails
 
         Example:
             Writing to a BytesIO stream:

--- a/newsfragments/30.feature.rst
+++ b/newsfragments/30.feature.rst
@@ -1,0 +1,1 @@
+Add stream I/O methods ``Multihash.read()`` and ``Multihash.write()`` for reading and writing multihashes from/to binary streams.


### PR DESCRIPTION
### Summary

Closes #29 

Adds stream I/O methods (`Multihash.read()` and `Multihash.write()`) to enable reading and writing multihashes from/to binary streams, bringing `py-multihash` closer to feature parity with Go and Rust implementations.

This addresses a **Medium Priority** item from [Discussion #1061](https://github.com/libp2p/py-libp2p/discussions/1061).

### Changes

#### New Methods

**1. `Multihash.read(stream)` - Class Method**

Reads a varint-encoded multihash from a binary stream.

```python
@classmethod
def read(cls, stream: BinaryIO) -> "Multihash":
    """Read a multihash from a binary stream.
    
    Args:
        stream: A binary stream object with read() method
        
    Returns:
        Multihash: A new Multihash instance read from the stream
        
    Raises:
        ValueError: If the stream data is invalid or insufficient
    """
```

**Features:**
- Uses `varint.decode_stream()` to read code and length
- Validates hash codes using existing `is_valid_code()`
- Provides clear error messages for debugging
- Works with any `BinaryIO` object (files, BytesIO, sockets, etc.)

**2. `Multihash.write(stream)` - Instance Method**

Writes the multihash to a binary stream in varint-encoded format.

```python
def write(self, stream: BinaryIO) -> int:
    """Write this multihash to a binary stream.
    
    Args:
        stream: A binary stream object with write() method
        
    Returns:
        int: The number of bytes written to the stream
        
    Raises:
        TypeError: If stream is not a valid binary stream
        IOError: If writing to the stream fails
    """
```

**Features:**
- Writes in the same varint format as `encode()`
- Returns byte count for verification
- Direct stream writing without intermediate allocations
- Compatible with any writable binary stream

### API Compatibility

This implementation follows the **Rust multihash API pattern**:
- Rust: `Multihash::read()` and `Multihash::write()`
- Python: `Multihash.read()` and `mh.write()`

