### PR TITLE
add imports to docs setup

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,12 @@ extensions = [
     'sphinx.ext.doctest',
 ]
 
+# Doctest configuration
+doctest_global_setup = """
+from multihash import Multihash, MultihashSet, from_json, sum, digest
+from multihash.funcs import Func, Blake3Hash, Murmur3_128Hash, Murmur3_32Hash, DoubleSHA256Hash
+"""
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
Adding the required imports to multihash.rst caused newly generated docs to because it didn't automatically add those imports. Adding them to docs config here so they will always be present.