### PR TITLE
fix: correct broken format string in decode() TypeError message

### DIFF
--- a/multihash/multihash.py
+++ b/multihash/multihash.py
@@ -750,7 +750,7 @@ def decode(multihash):
     :raises ValueError: if the length is not same as the digest
     """
     if not isinstance(multihash, bytes):
-        raise TypeError("multihash should be bytes, not {}", type(multihash))
+        raise TypeError(f"multihash should be bytes, not {type(multihash)}")
 
     if len(multihash) < 3:
         raise ValueError("multihash must be greater than 3 bytes.")

--- a/newsfragments/47.bugfix.rst
+++ b/newsfragments/47.bugfix.rst
@@ -1,0 +1,1 @@
+Fix broken format string in :func:`multihash.decode` that caused the ``TypeError`` raised for non-bytes input to display a literal ``{}`` instead of the actual type. The error message now correctly interpolates the offending type (e.g. ``"<class 'str'>"``).

--- a/tests/test_multihash.py
+++ b/tests/test_multihash.py
@@ -233,6 +233,27 @@ class DecodeTestCase:
             decode(value)
         assert "should be bytes" in str(excinfo.value)
 
+    def test_decode_type_error_message_interpolates_type(self):
+        """decode: TypeError message must include the actual type, not a literal {}
+
+        Regression test for issue #47: the previous code used
+        ``TypeError("multihash should be bytes, not {}", type(multihash))`` without
+        an ``f`` prefix, so the ``{}`` placeholder was rendered literally and the
+        user saw ``"multihash should be bytes, not {}"`` instead of the offending
+        type.
+        """
+        with pytest.raises(TypeError) as excinfo:
+            decode("not bytes")
+        message = str(excinfo.value)
+        assert "should be bytes, not" in message
+        assert "{}" not in message
+        assert "<class 'str'>" in message
+
+        with pytest.raises(TypeError) as excinfo:
+            decode(["a", "b"])
+        assert "{}" not in str(excinfo.value)
+        assert "<class 'list'>" in str(excinfo.value)
+
     @pytest.mark.parametrize("value", (b"", b"a", b"aa"))
     def test_decode_less_length(self, value):
         """decode: raises ValueError if the length is less than 3"""


### PR DESCRIPTION
Fixes #47.

**What was broken**

The `decode()` function in `multihash/multihash.py` raised a `TypeError` using a non-f-string format:

```python
raise TypeError("multihash should be bytes, not {}", type(multihash))
```

Because the literal string is not prefixed with `f`, the `{}` placeholder is **not** interpolated — it is printed verbatim, with the offending type captured only as a separate element of `e.args`. The user sees:

```
TypeError: multihash should be bytes, not {}
# Expected: TypeError: multihash should be bytes, not <class 'str'>
```

**Fix**

Switch the literal to a proper f-string so the type is interpolated into the message at raise time:

```python
raise TypeError(f"multihash should be bytes, not {type(multihash)}")
```

**Tested**

- Added `test_decode_type_error_message_interpolates_type` in `tests/test_multihash.py` that asserts the message contains `"should be bytes, not"` and **does not** contain the literal `"{}"`.
- Verified the new test fails on the unpatched code (literal `{}` present) and passes on the patched code.
- Full test suite: 229 tests pass.
- Lint: `ruff check` clean on touched files.

**Files changed**

- `multihash/multihash.py` — fix the format string (1 line)
- `tests/test_multihash.py` — add regression test (21 lines)
- `newsfragments/47.bugfix.rst` — release note (new file)
