### PR TITLE
Fix: decode multi-byte varints correctly in get_prefix

### DIFF
--- a/multihash/multihash.py
+++ b/multihash/multihash.py
@@ -825,12 +825,18 @@ def get_prefix(multihash):
     :param bytes multihash: input multihash
     :return: multihash prefix
     :rtype: bytes
+    :raises TypeError: when multihash is not bytes
     :raises ValueError: when the multihash is invalid
     """
-    if is_valid(multihash):
-        return multihash[:2]
+    if not isinstance(multihash, bytes):
+        raise TypeError("multihash should be bytes")
+    if not is_valid(multihash):
+        raise ValueError("invalid multihash")
 
-    raise ValueError("invalid multihash")
+    buffer = BytesIO(multihash)
+    varint.decode_stream(buffer)  # Read code varint
+    varint.decode_stream(buffer)  # Read length varint
+    return multihash[: buffer.tell()]
 
 
 def sum(data: bytes, code: Func | str | int, length: int | None = None) -> Multihash:

--- a/tests/test_multihash.py
+++ b/tests/test_multihash.py
@@ -328,3 +328,19 @@ class GetPrefixTestCase:
         """get_prefix: raises ValueError for invalid cases"""
         with pytest.raises(ValueError):
             get_prefix(b"foobar")
+
+    def test_get_prefix_multi_byte_code(self):
+        """get_prefix: correctly parses multi-byte varints"""
+        from multihash.funcs import Func
+        from multihash.multihash import sum as mh_sum
+
+        # sha2_224 code is 0x1013, which takes 2 bytes for the varint.
+        # Length 28 takes 1 byte. Total prefix = 3 bytes.
+        mh = mh_sum(b"test", Func.sha2_224)
+        prefix = get_prefix(mh.encode())
+        assert prefix == mh.encode()[:3]
+
+    def test_get_prefix_type_error(self):
+        """get_prefix: raises TypeError when not passed bytes"""
+        with pytest.raises(TypeError):
+            get_prefix("not bytes")


### PR DESCRIPTION
### Description

Closes #46.

This pull request addresses issue, where `get_prefix` was returning an incomplete/incorrect prefix for hash functions utilizing multi-byte varint codes (e.g., hash functions with codes > `0x7F` like `sha2-224`, `blake2b-*`, etc.). 

The original code assumed a hardcoded 2-byte prefix size, expecting exactly one byte for the code varint and exactly one byte for the length varint.

### Proposed Changes
- Updates `get_prefix` to properly decode both the hash code varint and the digest length varint from the input stream using `BytesIO`, guaranteeing accuracy regardless of varint length.
- Adds test cases (`test_get_prefix_multi_byte_code` & `test_get_prefix_type_error`) ensuring accuracy against multi-byte codes (using `sha2_224` as an example).
